### PR TITLE
Added a simple option to pass a selector function or a property name

### DIFF
--- a/lib/arrayDiff.js
+++ b/lib/arrayDiff.js
@@ -13,16 +13,16 @@ function findDeltaWithinTwoArraysOfObjects(listOriginal, listNew, uniqueProp) {
     var _deltaMap = {};
     var _objHolder = {};
     listOriginal.forEach(function (item) {
-        _objHolder[uniqueProp && item[uniqueProp] || item] = item;
-        _deltaMap[uniqueProp && item[uniqueProp] || item] = 'remove';
+        _objHolder[uniqueProp && getItemValue(item, uniqueProp) || item] = item;
+        _deltaMap[uniqueProp && getItemValue(item, uniqueProp) || item] = 'remove';
     });
     listNew.forEach(function (item) {
-        _objHolder[uniqueProp && item[uniqueProp] || item] = item;
-        var d = _deltaMap[uniqueProp && item[uniqueProp] || item];
+        _objHolder[uniqueProp && getItemValue(item, uniqueProp) || item] = item;
+        var d = _deltaMap[uniqueProp && getItemValue(item, uniqueProp) || item];
         if (Boolean(d) && d == 'remove') {
-            _deltaMap[uniqueProp && item[uniqueProp] || item] = 'noChange';
+            _deltaMap[uniqueProp && getItemValue(item, uniqueProp) || item] = 'noChange';
         } else {
-            _deltaMap[uniqueProp && item[uniqueProp] || item] = 'added';
+            _deltaMap[uniqueProp && getItemValue(item, uniqueProp) || item] = 'added';
         }
     });
     Object.keys(_deltaMap).forEach(function (id) {
@@ -33,6 +33,16 @@ function findDeltaWithinTwoArraysOfObjects(listOriginal, listNew, uniqueProp) {
     return delta;
 }
 
+function getItemValue(item, uniqueProp) {
+	if (typeof uniqueProp==='string'){
+		return item[uniqueProp];
+	}
+	else if	(typeof uniqueProp==='function')
+	{
+		return uniqueProp(item);
+	}
+	throw 'Property selector should either be a property name or selector function.';
+}
 
 //Lets export the method as module require
 exports = module.exports = findDeltaWithinTwoArraysOfObjects;

--- a/tests/test.js
+++ b/tests/test.js
@@ -79,6 +79,63 @@ describe('Array Diff Test Suite', function () {
             assert.equal(result.removed.length, 3);
             done();
         });
+		
+		 it('should differentiate between object elements when selector is a function', function (done) {
+            var result = arrayDiff(
+                [
+                    {id:1, name: 'a'},
+                    {id:2, name: 'b'},
+                    {id:3, name: 'c'},
+                    {id:4, name: 'd'},
+                    {id:5, name: 'e'}
+                ],
+                [
+                    {id:1, name: 'a'},
+                    {id:2, name: 'b'},
+                    {id:7, name: 'e'}
+                ],
+                function (x)
+				{
+					return x.id;
+				}
+            );
+            console.log(result);
+            assert(result);
+            assert(result.added);
+            assert(result.removed);
+            assert.equal(result.added.length, 1);
+            assert.equal(result.removed.length, 3);
+            done();
+        });
+		
+		it('should differentiate between object elements when selector is a function regardless of object depth', function (done) {
+            var result = arrayDiff(
+                  [
+                    { id: 1, depthObj: { id: 1 }, name: 'a' },
+                    { id: 2, depthObj: { id: 2 }, name: 'b' },
+                    { id: 3, depthObj: { id: 3 }, name: 'c' },
+                    { id: 4, depthObj: { id: 4 }, name: 'd' },
+                    { id: 5, depthObj: { id: 5 }, name: 'e' }
+                ],
+                [
+                    { id: 1, depthObj: { id: 1 }, name: 'a' },
+                    { id: 2, depthObj: { id: 2 }, name: 'b' },
+                    { id: 7, depthObj: { id: 7 }, name: 'e' }
+                ],
+                function (x) {
+                    return x.depthObj.id;
+                }
+            );
+            console.log(result);
+            assert(result);
+            assert(result.added);
+            assert(result.removed);
+            assert.equal(result.added.length, 1);
+            assert.equal(result.removed.length, 3);
+            done();
+        });
+		
+		
 
     });
 


### PR DESCRIPTION
Just a simple change to be able to differentiate objects by using a selector function and to be able to compare objects on a deeper level of properties, like:

 var result = cdiff.findDiff2(
                [
                    { id: 1, depthObj: { id: 1 }, name: 'a' },
                    { id: 2, depthObj: { id: 2 }, name: 'b' },
                    { id: 3, depthObj: { id: 3 }, name: 'c' },
                    { id: 4, depthObj: { id: 4 }, name: 'd' },
                    { id: 5, depthObj: { id: 5 }, name: 'e' }
                ],
                [
                    { id: 1, depthObj: { id: 1 }, name: 'a' },
                    { id: 2, depthObj: { id: 2 }, name: 'b' },
                    { id: 7, depthObj: { id: 7 }, name: 'e' }
                ],
                function (x) {
                    return x.depthObj.id;
                }
            );
